### PR TITLE
ci: remove sonar check

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,12 +73,6 @@ jobs:
       - name: Test memory-constrained execution with segment repair
         shell: bash
         run: .github/mem-constrained-exec.sh
-      - name: Run Sonar
-        if: ${{ matrix.os == 'ubuntu-latest' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == 'ASSERT-KTH/sorald') }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
       - name: Upload coverage report to Codecov
         uses: codecov/codecov-action@40a12dcee2df644d47232dde008099a3e9e4f865 # v3.1.2
 


### PR DESCRIPTION
Removing Sonar check because it is throwing `500` in our CI job - https://github.com/ASSERT-KTH/sorald/actions/runs/4819525681/jobs/8583103332?pr=1029.

I never really bothered to check it so maybe it is okay to remove it. I have the plugin locally installed so it informs me of the sonar violations. If Sonar is fixed soon, I will integrate this back.