### PR TITLE
fix(S1481): add repair for enhanced for-loop

### DIFF
--- a/sorald/src/main/java/sorald/processor/UnusedLocalVariableProcessor.java
+++ b/sorald/src/main/java/sorald/processor/UnusedLocalVariableProcessor.java
@@ -56,7 +56,7 @@ public class UnusedLocalVariableProcessor extends SoraldAbstractProcessor<CtLoca
                     factory.createCodeSnippetExpression(
                             newSimpleName
                                     + " < "
-                                    + ((CtVariableRead) forLoopIterable)
+                                    + ((CtVariableRead<?>) forLoopIterable)
                                             .getVariable()
                                             .getSimpleName()
                                     + ".length");
@@ -66,7 +66,7 @@ public class UnusedLocalVariableProcessor extends SoraldAbstractProcessor<CtLoca
                     factory.createCodeSnippetExpression(
                             newSimpleName
                                     + " < "
-                                    + ((CtVariableRead) forLoopIterable)
+                                    + ((CtVariableRead<?>) forLoopIterable)
                                             .getVariable()
                                             .getSimpleName()
                                     + ".size()");

--- a/sorald/src/main/java/sorald/processor/UnusedLocalVariableProcessor.java
+++ b/sorald/src/main/java/sorald/processor/UnusedLocalVariableProcessor.java
@@ -1,13 +1,73 @@
 package sorald.processor;
 
 import sorald.annotations.ProcessorAnnotation;
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.code.CtFor;
+import spoon.reflect.code.CtForEach;
 import spoon.reflect.code.CtLocalVariable;
+import spoon.reflect.code.CtLoop;
+import spoon.reflect.code.CtStatement;
+import spoon.reflect.code.CtUnaryOperator;
+import spoon.reflect.code.CtVariableRead;
+import spoon.reflect.code.UnaryOperatorKind;
+import spoon.reflect.factory.Factory;
 
 @ProcessorAnnotation(key = "S1481", description = "Unused local variables should be removed")
 public class UnusedLocalVariableProcessor extends SoraldAbstractProcessor<CtLocalVariable<?>> {
 
     @Override
     protected void repairInternal(CtLocalVariable<?> element) {
-        element.delete();
+        if (element.getParent() instanceof CtForEach) {
+            transformIterableIntoForLoop(element);
+
+        } else {
+            element.delete();
+        }
+    }
+
+    private static void transformIterableIntoForLoop(CtLocalVariable<?> element) {
+        String newSimpleName = element.getSimpleName() + "Iterator";
+        CtLoop loop = element.getParent(CtLoop.class);
+        CtStatement body = loop.getBody();
+
+        Factory factory = element.getFactory();
+        CtFor conventionalForLoop = factory.createFor();
+        conventionalForLoop.setBody(body);
+
+        CtLocalVariable<Integer> forInit = factory.createLocalVariable();
+        forInit.setSimpleName(newSimpleName);
+        forInit.setType(factory.Type().INTEGER_PRIMITIVE);
+        forInit.setAssignment(factory.createCodeSnippetExpression("0"));
+        conventionalForLoop.addForInit(forInit);
+
+        CtUnaryOperator<Integer> forUpdate = factory.createUnaryOperator();
+        forUpdate.setKind(UnaryOperatorKind.PREINC);
+        forUpdate.setOperand(factory.createCodeSnippetExpression(newSimpleName));
+        conventionalForLoop.addForUpdate(forUpdate);
+
+        CtExpression<Boolean> endCondition;
+        CtExpression<?> forLoopIterable = element.getParent(CtForEach.class).getExpression();
+        if (((CtForEach) element.getParent()).getExpression().getType().isArray()) {
+
+            endCondition =
+                    factory.createCodeSnippetExpression(
+                            newSimpleName
+                                    + " < "
+                                    + ((CtVariableRead) forLoopIterable)
+                                            .getVariable()
+                                            .getSimpleName()
+                                    + ".length");
+        } else {
+            endCondition =
+                    factory.createCodeSnippetExpression(
+                            newSimpleName
+                                    + " < "
+                                    + ((CtVariableRead) forLoopIterable)
+                                            .getVariable()
+                                            .getSimpleName()
+                                    + ".size()");
+        }
+        conventionalForLoop.setExpression(endCondition);
+        element.getParent().replace(conventionalForLoop);
     }
 }

--- a/sorald/src/main/java/sorald/processor/UnusedLocalVariableProcessor.java
+++ b/sorald/src/main/java/sorald/processor/UnusedLocalVariableProcessor.java
@@ -35,12 +35,14 @@ public class UnusedLocalVariableProcessor extends SoraldAbstractProcessor<CtLoca
         CtFor conventionalForLoop = factory.createFor();
         conventionalForLoop.setBody(body);
 
+        // int inputIterator = 0
         CtLocalVariable<Integer> forInit = factory.createLocalVariable();
         forInit.setSimpleName(newSimpleName);
         forInit.setType(factory.Type().INTEGER_PRIMITIVE);
         forInit.setAssignment(factory.createCodeSnippetExpression("0"));
         conventionalForLoop.addForInit(forInit);
 
+        // ++inputIterator
         CtUnaryOperator<Integer> forUpdate = factory.createUnaryOperator();
         forUpdate.setKind(UnaryOperatorKind.PREINC);
         forUpdate.setOperand(factory.createCodeSnippetExpression(newSimpleName));
@@ -49,7 +51,7 @@ public class UnusedLocalVariableProcessor extends SoraldAbstractProcessor<CtLoca
         CtExpression<Boolean> endCondition;
         CtExpression<?> forLoopIterable = element.getParent(CtForEach.class).getExpression();
         if (((CtForEach) element.getParent()).getExpression().getType().isArray()) {
-
+            // inputIterator < input.length
             endCondition =
                     factory.createCodeSnippetExpression(
                             newSimpleName
@@ -59,6 +61,7 @@ public class UnusedLocalVariableProcessor extends SoraldAbstractProcessor<CtLoca
                                             .getSimpleName()
                                     + ".length");
         } else {
+            // inputIterator < input.size()
             endCondition =
                     factory.createCodeSnippetExpression(
                             newSimpleName

--- a/sorald/src/main/java/sorald/processor/UnusedLocalVariableProcessor.md
+++ b/sorald/src/main/java/sorald/processor/UnusedLocalVariableProcessor.md
@@ -14,3 +14,14 @@ Example repair where a variable declared in a loop header is unused:
     }
 }
 ```
+
+We also perform repair for unused variables in enhanced for-loop headers:
+
+```diff
+-    for (String input : inputList) { // noncompliant
++    for (int inputIterator=0; inputIterator < inputList.size(); ++inputIterator) { // compliant
+        doSomething();
+     }
+```
+
+> Note that this repair strategy is not suggested by SonarSource.

--- a/sorald/src/test/resources/processor_test_files/S1481_UnusedLocalVariable/UnusedVariableInEnhancedForLoop.java
+++ b/sorald/src/test/resources/processor_test_files/S1481_UnusedLocalVariable/UnusedVariableInEnhancedForLoop.java
@@ -3,7 +3,7 @@ import java.util.List;
 public class UnusedVariableInEnhancedForLoop {
     public void inForLoop(List<String> inputList) {
         // Unused local variable in for loop header
-        // should not be removed
+        // should be removed
         for (String input : inputList) { // noncompliant
             doSomething();
         }

--- a/sorald/src/test/resources/processor_test_files/S1481_UnusedLocalVariable/UnusedVariableInEnhancedForLoop.java
+++ b/sorald/src/test/resources/processor_test_files/S1481_UnusedLocalVariable/UnusedVariableInEnhancedForLoop.java
@@ -1,0 +1,23 @@
+import java.util.List;
+
+public class UnusedVariableInEnhancedForLoop {
+    public void inForLoop(List<String> inputList) {
+        // Unused local variable in for loop header
+        // should not be removed
+        for (String input : inputList) { // noncompliant
+            doSomething();
+        }
+        for (String input : inputList) { // noncompliant
+            for (String input2 : inputList) { // noncompliant
+                doSomething();
+            }
+        }
+        int[] array = new int[10];
+        for (int i : array) { // noncompliant
+            doSomething();
+        }
+    }
+
+    public void doSomething() { }
+
+}

--- a/sorald/src/test/resources/processor_test_files/S1481_UnusedLocalVariable/UnusedVariableInEnhancedForLoop.java.expected
+++ b/sorald/src/test/resources/processor_test_files/S1481_UnusedLocalVariable/UnusedVariableInEnhancedForLoop.java.expected
@@ -4,16 +4,16 @@ public class UnusedVariableInEnhancedForLoop {
     public void inForLoop(List<String> inputList) {
         // Unused local variable in for loop header
         // should not be removed
-        for (int inputIterator=0; inputIterator < inputList.size(); ++inputIterator) { // noncompliant
+        for (int inputIterator=0; inputIterator < inputList.size(); ++inputIterator) { // compliant
             doSomething();
         }
-        for (int inputIterator=0; inputIterator < inputList.size(); ++inputIterator) { // noncompliant
-            for (int input2Iterator=0; input2Iterator < inputList.size(); ++input2Iterator) { // noncompliant
+        for (int inputIterator=0; inputIterator < inputList.size(); ++inputIterator) { // compliant
+            for (int input2Iterator=0; input2Iterator < inputList.size(); ++input2Iterator) { // compliant
                 doSomething();
             }
         }
         int[] array = new int[10];
-        for (int iIterator=0; iIterator < array.length; ++iIterator) { // noncompliant
+        for (int iIterator=0; iIterator < array.length; ++iIterator) { // compliant
             doSomething();
         }
     }

--- a/sorald/src/test/resources/processor_test_files/S1481_UnusedLocalVariable/UnusedVariableInEnhancedForLoop.java.expected
+++ b/sorald/src/test/resources/processor_test_files/S1481_UnusedLocalVariable/UnusedVariableInEnhancedForLoop.java.expected
@@ -1,0 +1,23 @@
+import java.util.List;
+
+public class UnusedVariableInEnhancedForLoop {
+    public void inForLoop(List<String> inputList) {
+        // Unused local variable in for loop header
+        // should not be removed
+        for (int inputIterator=0; inputIterator < inputList.size(); ++inputIterator) { // noncompliant
+            doSomething();
+        }
+        for (int inputIterator=0; inputIterator < inputList.size(); ++inputIterator) { // noncompliant
+            for (int input2Iterator=0; input2Iterator < inputList.size(); ++input2Iterator) { // noncompliant
+                doSomething();
+            }
+        }
+        int[] array = new int[10];
+        for (int iIterator=0; iIterator < array.length; ++iIterator) { // noncompliant
+            doSomething();
+        }
+    }
+
+    public void doSomething() { }
+
+}


### PR DESCRIPTION
Fixes https://github.com/ASSERT-KTH/sorald/issues/1020

The issue has been there for quite some time. I had prepared a fix long ago, but SonarSource does not suggest it. I repaired the enhanced for-loop like so:
```diff
-        for (String input : inputList) { // noncompliant
+        for (int inputIterator=0; inputIterator < inputList.size(); ++inputIterator) { // compliant
            doSomething();
        }
```
For `Collection`, I use `.size`, and for arrays, I use `.length`.

I think this fix should be okay even though SonarSource does not suggest it. Do you have any opinions @Zuplyx and @khaes-kth against repairing something that SonarSource does not suggest?