### PR TITLE
ci: use skipTests for skipping tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
           distribution: ${{ env.JAVA_DISTRIBUTION }}
 
       - name: Build
-        run: mvn -B install -DskipUnitTests=true -DskipIntegrationTests=true
+        run: mvn -B install -DskipTests
 
       - name: Get Sorald version
         id: get-sorald-version
@@ -59,7 +59,7 @@ jobs:
         run: |
           mvn -Prelease deploy -pl se.kth.castor:sorald-parent # Fully qualified artifact ID is required
           mvn -Prelease deploy -pl sorald-api
-          mvn -Prelease deploy -pl sorald -DskipUnitTests=true -DskipIntegrationTests=true
+          mvn -Prelease deploy -pl sorald -DskipTests
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_CENTRAL_TOKEN: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/jreleaser.yml
+++ b/.github/workflows/jreleaser.yml
@@ -62,7 +62,7 @@ jobs:
 
       # Now we can run the release
       - name: Stage release
-        run:  mvn --no-transfer-progress --batch-mode -Prelease clean deploy -DskipUnitTests -DskipIntegrationTests -DaltDeploymentRepository=local::default::file://`pwd`/target/staging-deploy
+        run:  mvn --no-transfer-progress --batch-mode -Prelease clean deploy -DskipTests -DaltDeploymentRepository=local::default::file://`pwd`/target/staging-deploy
       - name: Print next version
         run: mvn help:evaluate -Dexpression=project.version -q -DforceStdout | sed 's/-SNAPSHOT//'
       - name: Run JReleaser

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -99,7 +99,7 @@ jobs:
           restore-keys: ${{ runner.os }}-maven-
 
       - name: Package Sorald
-        run: mvn package -DskipUnitTests
+        run: mvn package -DskipTests
       - name: Test support scripts
         run: |
           cd experimentation/tools
@@ -132,7 +132,7 @@ jobs:
 
       - name: Test that generated code is up-to-date
         run: |
-          mvn install -DskipUnitTests -DskipIntegrationTests
+          mvn install -DskipTests
           mvn clean compile dependency:build-classpath -Dmdep.outputFile=cp.txt
           (cd sorald && java -cp "$(cat cp.txt):target/classes" sorald.CodeGenerator)
           mvn spotless:apply

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,17 +59,13 @@ jobs:
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: mvn spotless:check
       - name: Build project
-        run: |
-          mvn -B package -DskipUnitTests
-          mvn -B test-compile
+        run: mvn -B install -DskipTests
       - name: Fetch final dependencies
         # this is a hack to fetch some test runtime dependencies
         run: timeout 10 mvn -B test || echo "Done fetching dependencies"
         shell: bash
-      - name: Run tests
-        run: mvn test
-      - name: Run integration tests
-        run: mvn -B install -DskipUnitTests
+      - name: Run unit tests and integration tests
+        run: mvn -B verify
       - name: Test memory-constrained execution with segment repair
         shell: bash
         run: .github/mem-constrained-exec.sh

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ renaming the JAR to `sorald.jar` for the sake of simplicity.
 
  ```bash
 $ cd sorald
-$ mvn package -DskipUnitTests
+$ mvn package -DskipTests
 $ cp sorald/target/sorald-*-jar-with-dependencies.jar sorald.jar
  ```
 

--- a/sorald/pom.xml
+++ b/sorald/pom.xml
@@ -225,11 +225,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.1.2</version>
-                <!-- Used to run ONLY integration tests and skip the unit tests -->
-                <!-- Run it like so: `mvn verify -DskipUnitTests` -->
-                <configuration>
-                    <skipTests>${skipUnitTests}</skipTests>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -322,9 +317,6 @@
                         </goals>
                     </execution>
                 </executions>
-                <configuration>
-                    <skipTests>${skipIntegrationTests}</skipTests>
-                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
We used `-DskipUnitTests` and `-DskipIntegrationTests` for ci before these changes. I am reverting it back to use `-Dskip` which would act on both types of test. The advantage of it is following convention.